### PR TITLE
Addressing "implicitly nullable parameter" deprecation warning in PHP8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "spryng/rest-api-php",
+    "name": "janforth/rest-api-php",
     "description": "Implementation of the REST API in PHP",
     "type": "library",
     "license": "BSD-2-Clause",
@@ -21,7 +21,10 @@
     },
     "autoload": {
         "psr-4": {
-            "Spryng\\SpryngRestApi\\": "src/Spryng/SpryngRestApi"
+          "Janforth\\RestApi\\": "src/"
         }
-    }
+    },
+  "require": {
+    "php": ">=8.1"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "autoload": {
         "psr-4": {
-          "Janforth\\RestApi\\": "src/"
+          "Spryng\\SpryngRestApi\\": "src/"
         }
     },
   "require": {

--- a/src/Spryng/SpryngRestApi/Http/HttpClient.php
+++ b/src/Spryng/SpryngRestApi/Http/HttpClient.php
@@ -24,7 +24,7 @@ class HttpClient implements HttpClientInterface
      */
     protected $lastResponse;
 
-    public function __construct(Request $req = null)
+    public function __construct(Request|null $req = null)
     {
         $this->ch = curl_init();
 
@@ -34,7 +34,7 @@ class HttpClient implements HttpClientInterface
         }
     }
 
-    public function send(Request $req = null)
+    public function send(Request|null $req = null)
     {
         if ($req === null) {
             if ($this->activeRequest === null) {
@@ -99,7 +99,7 @@ class HttpClient implements HttpClientInterface
      * @param Request $req
      * @return HttpClientInterface
      */
-    public function setActiveRequest(Request $req)
+    public function setActiveRequest(Request|null $req)
     {
         $this->activeRequest = $req;
 

--- a/src/Spryng/SpryngRestApi/Http/HttpClientInterface.php
+++ b/src/Spryng/SpryngRestApi/Http/HttpClientInterface.php
@@ -13,18 +13,18 @@ interface HttpClientInterface
     /**
      * Executes the currently active request or $req if it is set.
      *
-     * @param Request $req
+     * @param Request|null $req
      * @return Response
      */
-    public function send(Request $req = null);
+    public function send(Request|null $req = null);
 
     /**
      * Sets the current request to be activated to $req
      *
-     * @param Request $req
+     * @param Request|null $req
      * @return HttpClientInterface
      */
-    public function setActiveRequest(Request $req);
+    public function setActiveRequest(Request|null $req);
 
     /**
      * Returns the lastResponse of the last request that was send.


### PR DESCRIPTION
Addressing "Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead" deprecation warning in PHP 8.4; PHP 8.0 minimum now required